### PR TITLE
Add coverage via Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,7 @@ script:
   - export THEANO_FLAGS='floatX=float32,gcc.cxxflags="-march=core2"'  && export SKIP_PLOT_TEST='YES' && nosetests
   - export THEANO_FLAGS='floatX=float64,gcc.cxxflags="-march=core2"' && export SKIP_PLOT_TEST='YES' && nosetests
   - flake8 neupy
+
+after_success:
+  - pip install codecov
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Travis|_ |Dependency Status|_ |License|_
+|Travis|_ |Coverage|_ |Dependency Status|_ |License|_
 
 .. |Travis| image:: https://api.travis-ci.org/itdxer/neupy.png?branch=master
 .. _Travis: https://travis-ci.org/itdxer/neupy
@@ -8,6 +8,9 @@
 
 .. |License| image:: https://img.shields.io/badge/license-MIT-blue.svg
 .. _License: https://github.com/itdxer/neupy/blob/master/LICENSE
+
+.. |Coverage| image:: https://codecov.io/gh/itdexer/neupy/branch/master/graph/badge.svg
+.. _Coverage: https://codecov.io/gh/itdxer/neupy
 
 
 .. raw:: html

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,7 @@ matplotlib==1.5.3
 
 nose==1.3.6
 flake8==2.2.5
-coverage==4.0.1
+coverage==4.5.1
 mock==2.0.0
 nose-timer==0.7.0
 

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -17,6 +17,7 @@ dill==0.2.3
 nose==1.3.7
 flake8==2.2.5
 mock==2.0.0
+coverage==4.5.1
 
 # Storage module
 h5py==2.7.0


### PR DESCRIPTION
- Adds coverage reporting via codecov.io
- Bumps coverage.py to 4.5.1 for Python 3.6+ compat