### PR TITLE
Add ability to stop plot_errors() blocking execution of code

### DIFF
--- a/neupy/algorithms/base.py
+++ b/neupy/algorithms/base.py
@@ -210,11 +210,12 @@ class BaseNetwork(BaseSkeleton):
     def score(self, X, y):
         raise NotImplementedError()
 
-    def plot_errors(self, logx=False, show=True, **figkwargs):
+    def plot_errors(self, logx=False, show=True, pause=True, **figkwargs):
         return plot_optimizer_errors(
             optimizer=self,
             logx=logx,
             show=show,
+            pause=pause,
             **figkwargs
         )
 

--- a/neupy/algorithms/plots.py
+++ b/neupy/algorithms/plots.py
@@ -72,7 +72,7 @@ def plot_error_per_epoch(train, valid, ax, logx=False):
     ax.set_xlabel('Number of training epochs passed')
 
 
-def plot_optimizer_errors(optimizer, logx=False, show=True, **figkwargs):
+def plot_optimizer_errors(optimizer, logx=False, show=True, pause=False, **figkwargs):
     if 'figsize' not in figkwargs:
         figkwargs['figsize'] = (12, 8)
 
@@ -98,4 +98,4 @@ def plot_optimizer_errors(optimizer, logx=False, show=True, **figkwargs):
         plot_error_per_epoch(train, valid, logx=logx, ax=axes[1])
 
     if show:
-        plt.show()
+        plt.show(block=pause)


### PR DESCRIPTION
### Summary
This change will allow the user to use matplotlib's block parameter. By default all calls to the plot's `show()` function will pause execution of the program until the plot is dismissed. However, by specifying `block=False`, the program will continue to run after the plot appears instead of waiting for the plot to be dismissed.
### Why it is useful
Some programs will want the plot to be produced while other calculations/operations are running.
### Explanation of changes
 Added a new parameter called `pause` to the `plot_errors()` function that will funnel down to become the `block` parameter in the plot's `show()` function. The default value for this parameter is `True`, this means the original behavior of the function will not be changed.
### How it will affect existing code
Unless the `pause` parameter is explicitly set to `False`, existing code will behave exactly as before.

