### PR TITLE
Addressing issue 251: return PIL image object from plot_errors()

### DIFF
--- a/neupy/algorithms/base.py
+++ b/neupy/algorithms/base.py
@@ -210,11 +210,12 @@ class BaseNetwork(BaseSkeleton):
     def score(self, X, y):
         raise NotImplementedError()
 
-    def plot_errors(self, logx=False, show=True, **figkwargs):
+    def plot_errors(self, logx=False, show=True, image=False, **figkwargs):
         return plot_optimizer_errors(
             optimizer=self,
             logx=logx,
             show=show,
+            image=image,
             **figkwargs
         )
 

--- a/neupy/algorithms/plots.py
+++ b/neupy/algorithms/plots.py
@@ -1,6 +1,9 @@
 import pkgutil
 import warnings
 import importlib
+import numpy
+
+from PIL import Image
 
 import matplotlib.pyplot as plt
 
@@ -72,7 +75,7 @@ def plot_error_per_epoch(train, valid, ax, logx=False):
     ax.set_xlabel('Number of training epochs passed')
 
 
-def plot_optimizer_errors(optimizer, logx=False, show=True, **figkwargs):
+def plot_optimizer_errors(optimizer, logx=False, show=True, image=False, **figkwargs):
     if 'figsize' not in figkwargs:
         figkwargs['figsize'] = (12, 8)
 
@@ -99,3 +102,38 @@ def plot_optimizer_errors(optimizer, logx=False, show=True, **figkwargs):
 
     if show:
         plt.show()
+
+    if image:
+        return figure_to_image(fig)
+
+
+
+def figure_to_data(figure):
+    """
+    @brief Convert a Matplotlib figure to a 4D numpy array with RGBA channels and return it
+    @param figure - a matplotlib figure
+    @return a numpy 3D array of RGBA values
+    """
+    # draw the renderer
+    figure.canvas.draw()
+
+    # Get the RGBA buffer from the figure
+    w, h = figure.canvas.get_width_height()
+    np_array = numpy.fromstring(fig.canvas.tostring_argb(), dtype=numpy.uint8)
+    np_array.shape = (w, h, 4)
+
+    # canvas.tostring_argb give pixmap in ARGB mode. Roll the ALPHA channel to have it in RGBA mode
+    np_array = numpy.roll(np_array, 3, axis=2)
+    return np_array
+
+
+def figure_to_image(figure):
+    """
+    @brief Convert a Matplotlib figure to a PIL Image in RGBA format and return it
+    @param fig a matplotlib figure
+    @return a Python Imaging Library ( PIL ) image
+    """
+    # put the figure pixmap into a numpy array
+    buf = figure_to_data(figure)
+    w, h, d = buf.shape
+    return Image.fromstring("RGBA", (w, h), buf.tostring())

--- a/neupy/algorithms/plots.py
+++ b/neupy/algorithms/plots.py
@@ -76,6 +76,8 @@ def plot_error_per_epoch(train, valid, ax, logx=False):
 
 
 def plot_optimizer_errors(optimizer, logx=False, show=True, image=False, **figkwargs):
+    if image:
+        show=False
     if 'figsize' not in figkwargs:
         figkwargs['figsize'] = (12, 8)
 
@@ -119,7 +121,7 @@ def figure_to_data(figure):
 
     # Get the RGBA buffer from the figure
     w, h = figure.canvas.get_width_height()
-    np_array = numpy.fromstring(fig.canvas.tostring_argb(), dtype=numpy.uint8)
+    np_array = numpy.fromstring(figure.canvas.tostring_argb(), dtype=numpy.uint8)
     np_array.shape = (w, h, 4)
 
     # canvas.tostring_argb give pixmap in ARGB mode. Roll the ALPHA channel to have it in RGBA mode
@@ -136,4 +138,4 @@ def figure_to_image(figure):
     # put the figure pixmap into a numpy array
     buf = figure_to_data(figure)
     w, h, d = buf.shape
-    return Image.fromstring("RGBA", (w, h), buf.tostring())
+    return Image.frombytes("RGBA", (w, h), buf.tostring())


### PR DESCRIPTION
### Summary

This change will allow the user to have an image object passed back from calling `plot_errors()`, which gives the user more processing options then the current show parameter

### Addresses:
https://github.com/itdxer/neupy/issues/251


### Why it is useful

It will allow users more direct control of how they process the `plot_errors()` visual, whether it be saving to disk or placing in a GUI canvas.


### Explanation of changes

Added a new parameter called image to the `plot_errors()` function that will funnel down to `plot_optimizer_errors()` and cause an image object to be returned instead of 
the functionality the show paramater has of having a matplotlib window open and showing the figure


### How it will affect existing code
Unless the image parameter is explicitly set to `True`, existing code will behave exactly as before. Adds another means to bypass matplotlibs blocking behavior. 
Also, adds Pillow as a dependency. 


### Example

An example of this modification working within an application can be found below:
https://github.com/DPR-Sanchez/neural-net-models/tree/canvas-feature
