### PR TITLE
Fix Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ cache: pip
 python:
   - "2.7"
   - "3.6"
+  
+services:
+  - xvfb
 
 install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -28,9 +31,6 @@ install:
 before_script:
   - sudo apt-get -qq update > /dev/null
   - sudo apt-get -qq install graphviz > /dev/null
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"  # `xvfb` is important for matplotlib tests
-  - sleep 3  # give xvfb some time to start
 
 script:
   - pytest --cov=neupy


### PR DESCRIPTION
### Summary 
Changed the config file for Travis CI to reflect some changes made to the way Xvfb works. 
### Explanation of changes 
A change was made to Travis CI that resulted in builds using Xvfb to fail because of this change. As documented in the [changelog](https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-update-86123) the new way to use Xvfb is by defining it in your config file as a service like so:
```yaml
services:
  - xvfb
```
I ran a build using the config from the master branch, and it failed with the following error message:
`The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .` ([link to full log](https://travis-ci.org/FrostByte266/neupy/jobs/579904186))
As you can see this is the same error as described in [this blog post](https://benlimmer.com/2019/01/14/travis-ci-xvfb/), and the solution mentioned is to change to the Xvfb service just as this pull request does.

After making these changes, the build completes successfully ([link to build](https://travis-ci.org/FrostByte266/neupy/builds/579911503))